### PR TITLE
DM-21528: Add Jinja filter that escapes content for double-quoted YAML string fields

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,15 @@
 Change log
 ##########
 
+0.3.0 (2019-10-08)
+==================
+
+- A new Jinja filter, ``escape_yaml_doublequoted``, is available as part of the `templatekit.TemplatekitExtension`.
+  This filter is meant to be used with template variables that are inside double-quoted string fields in a YAML file.
+  The filter escapes both double quote characters (``"``) and backslash characters (``\``).
+- There is a new "Template developer" guide, which lists the ``escape_yaml_doublequoted`` filter and provides tips on how to write YAML files in templates.
+- The development procedure is now part of the documentation, rather than the README.
+
 0.2.0 (2019-04-16)
 ==================
 

--- a/README.rst
+++ b/README.rst
@@ -6,31 +6,8 @@ Templatekit is a Python library and command-line app for using and maintaining a
 Templates are built with Cookiecutter_ and Jinja_.
 https://github.com/lsst/templates is the primary repository that Templatekit is built for, but Templatekit can be used for other template repository projects.
 
-Development
-===========
-
-Clone Templatekit with test data (`lsst/templates`_)::
-
-   git clone --recursive-submodules https://github.com/lsst-sqre/templatekit
-
-Install the package for development (do this in a `virtual environment`_)::
-
-   cd templatekit
-   pip install -e ".[dev]"
-
-Run tests::
-
-   pytest
-
-You can also run tests without installing Templatekit first::
-
-   python setup.py test
-
-Occasionally you may need to update the ``tests/data/templates`` submodule::
-
-   git submodule update --recursive
+Read the docs at https://templatekit.lsst.io
 
 .. _Cookiecutter: https://cookiecutter.readthedocs.io/en/latest/
 .. _Jinja: http://jinja.pocoo.org
 .. _lsst/templates: https://github.com/lsst/templates
-.. _virtual environment: https://docs.python.org/3/library/venv.html

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -85,7 +85,15 @@ default_role = 'py:obj'
 
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3/', None),
+    'cookiecutter': ('https://cookiecutter.readthedocs.io/en/latest/', None),
 }
+
+rst_epilog = """
+
+.. _Cookiecutter: https://cookiecutter.readthedocs.io/en/latest/
+.. _Jinja: http://jinja.pocoo.org
+.. _lsst/templates: https://github.com/lsst/templates
+"""
 
 # -- Options for linkcheck builder ----------------------------------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -39,7 +39,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'Templatekit'
-copyright = '2018 Association of Universities for Research in Astronomy'
+copyright = '2018-2019 Association of Universities for Research in Astronomy'
 author = 'LSST Data Management'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/docs/development-guide.rst
+++ b/docs/development-guide.rst
@@ -1,0 +1,61 @@
+#################
+Development guide
+#################
+
+Building and testing
+====================
+
+Clone Templatekit with test data (`lsst/templates`_):
+
+.. code-block:: bash
+
+   git clone --recursive-submodules https://github.com/lsst-sqre/templatekit
+
+Install the package for development (do this in a `virtual environment`_):
+
+.. code-block:: bash
+
+   cd templatekit
+   pip install -e ".[dev]"
+
+Run tests:
+
+.. code-block:: bash
+
+   pytest
+
+You can also run tests without installing Templatekit first:
+
+.. code-block:: bash
+
+   python setup.py test
+
+Occasionally you may need to update the ``tests/data/templates`` submodule:
+
+.. code-block:: bash
+
+   git submodule update --recursive
+
+Release process
+===============
+
+.. note::
+
+   Releases are generally only done by Templatekit's lead engineer (Jonathan Sick).
+
+Starting from a development branch:
+
+1. Ensure that the change log (``CHANGELOG.rst``) is up-to-date.
+2. Ensure that the Travis CI tests pass.
+   The ``master`` branch is protected on GitHub to assure this.
+3. Merge to master using a non-fast-forward merge.
+4. Tag using a :pep:`440`-compatible version identifier.
+
+   .. code-block:: bash
+
+      git tag -s X.Y.Z -m "X.Y.Z"
+      git push --tags
+
+Travis CI will create a new release on PyPI.
+
+.. _virtual environment: https://docs.python.org/3/library/venv.html

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,7 +8,7 @@ LSST's https://github.com/lsst/templates is the primary repository that Template
 Installation
 ============
 
-Templatekit is available from PyPI:
+Templatekit is available from `PyPI <https://pypi.org/project/templatekit/>`_:
 
 .. code-block:: sh
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -22,6 +22,14 @@ User guide
 
    cli-reference
 
+Template development guide
+==========================
+
+.. toctree::
+   :maxdepth: 2
+
+   template-guide/index
+
 Project information
 ===================
 
@@ -29,7 +37,3 @@ Project information
    :maxdepth: 1
 
    changelog
-
-.. _Cookiecutter: https://cookiecutter.readthedocs.io/en/latest/
-.. _Jinja: http://jinja.pocoo.org
-.. _lsst/templates: https://github.com/lsst/templates

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -37,3 +37,4 @@ Project information
    :maxdepth: 1
 
    changelog
+   development-guide

--- a/docs/template-guide/index.rst
+++ b/docs/template-guide/index.rst
@@ -1,0 +1,11 @@
+##########################
+Template development guide
+##########################
+
+This guide will help you develop templates for the templatekit system.
+
+.. toctree::
+   :maxdepth: 1
+
+   templatekit-jinja-extensions
+   templating-yaml-files

--- a/docs/template-guide/templatekit-jinja-extensions.rst
+++ b/docs/template-guide/templatekit-jinja-extensions.rst
@@ -1,0 +1,36 @@
+##############################
+Templatekit's Jinja extensions
+##############################
+
+Templatekit provides several custom Jinja extensions that you can use to process content in your templates.
+To use these extensions, remember to enable them by adding ``templatekit.TemplatekitExtension`` to the ``_extensions`` array in your template's ``cookiecutter.json`` file:
+
+.. code-block:: json
+
+   {
+     "_extensions": ["templatekit.TemplatekitExtension"]
+   }
+
+If the ``_extensions`` field doesn't already exist, you can add it.
+For more information, see :ref:`Template extensions <cookiecutter:template extensions>` in the Cookiecutter_ documentation.
+
+.. _escape_yaml_doublequoted:
+
+escape\_yaml\_doublequoted
+==========================
+
+This filter to escapes content that you add to double-quoted string fields in a YAML file.
+Consider this YAML template:
+
+.. code-block:: jinja
+
+   ---
+   my_field: "{{ cookiecutter.my_variable | escape_yaml_doublequoted }}"
+
+The ``escape_yaml_doublequoted`` filter escapes double quote (``"``) and backslash (``\``) characters.
+For example, if the value of ``my_variable`` is ``Hello "world" \ Bonjour!``, the rendered YAML will be:
+
+.. code-block:: yaml
+
+   ---
+   my_field: "Hello \"world\" \\ Bonjour!"

--- a/docs/template-guide/templating-yaml-files.rst
+++ b/docs/template-guide/templating-yaml-files.rst
@@ -1,0 +1,16 @@
+##############################
+Tips for templating YAML files
+##############################
+
+Use double-quoted string fields with the escape_yaml_doublequoted filter
+========================================================================
+
+If you are templating a string field in a YAML file, it's a good idea to make it an double-quoted string field.
+Double-quoted string fields are the only style of YAML `capable of holding arbitrary content <https://yaml.org/spec/1.2/spec.html#id2787109>`_.
+You do need to ensure that double quote (``"``) and backslash (``\``) characters are escaped, though.
+You can do this with the :ref:`escape_yaml_doublequoted` filter:
+
+.. code-block:: jinja
+
+   ---
+   my_field: "{{ cookiecutter.my_variable | escape_yaml_doublequoted }}"

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ install_requires = [
     'scons>=3.0.1,<3.1.0',
     'click>=6.7,<7.0',
     'pyperclip>=1.6.0,<1.7.0',
-    'PyYAML>=3.13,<4.0',
+    'PyYAML>=5.1',
     'Cerberus>=1.2,<2.0'
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ install_requires = [
 
 # Test dependencies
 tests_require = [
-    'pytest==4.2.0',
+    'pytest==5.2.1',
     'pytest-flake8==1.0.4',
 ]
 tests_require += install_requires
@@ -48,7 +48,7 @@ extras_require = {
 
 # Setup-time dependencies
 setup_requires = [
-    'pytest-runner>=4.2.0,<5.0.0',
+    'pytest-runner>=5.0.0',
     'setuptools_scm',
 ]
 

--- a/templatekit/jinjaext.py
+++ b/templatekit/jinjaext.py
@@ -5,7 +5,8 @@ __all__ = ('convert_py_to_cpp_namespace_code',
            'convert_py_namespace_to_cpp_header_def',
            'convert_py_to_cpp_namespace',
            'convert_py_namespace_to_includes_dir',
-           'convert_py_namespace_to_header_filename')
+           'convert_py_namespace_to_header_filename',
+           'escape_yaml_doublequoted')
 
 import os
 from jinja2.ext import Extension
@@ -43,6 +44,8 @@ class TemplatekitExtension(Extension):
       (`convert_py_namespace_to_includes_dir`)
     - ``convert_py_namespace_to_header_filename``
       (`convert_py_namespace_to_header_filename`)
+    - ``escape_yaml_doublequoted``
+      (`escape_yaml_doublequoted`)
     """
 
     def __init__(self, environment):
@@ -53,6 +56,7 @@ class TemplatekitExtension(Extension):
         environment.filters['convert_py_to_cpp_namespace'] = convert_py_to_cpp_namespace  # noqa: E501
         environment.filters['convert_py_namespace_to_includes_dir'] = convert_py_namespace_to_includes_dir  # noqa: E501
         environment.filters['convert_py_namespace_to_header_filename'] = convert_py_namespace_to_header_filename  # noqa: E501
+        environment.filters['escape_yaml_doublequoted'] = escape_yaml_doublequoted  # noqa: E501
 
 
 def convert_py_to_cpp_namespace_code(python_namespace):
@@ -156,3 +160,27 @@ def convert_py_namespace_to_header_filename(python_namespace):
     """
     parts = python_namespace.split('.')
     return parts[-1] + '.h'
+
+
+def escape_yaml_doublequoted(string):
+    r"""Escape the content of a double-quoted YAML string.
+
+    Parameters
+    ----------
+    string : `str`
+        A string.
+
+    Returns
+    -------
+    escaped_string : `str`
+        A string escaped so it can be safely inserted into a double-quoted
+        YAML string.
+
+    Notes
+    -----
+    To escape a double-quoted YAML string:
+
+    - Replace ``\`` with ``\\``.
+    - Replace ``"`` with ``"\``.
+    """
+    return string.replace('\\', '\\\\').replace('"', '\\"')

--- a/tests/test_jinjaext.py
+++ b/tests/test_jinjaext.py
@@ -8,7 +8,8 @@ from templatekit.jinjaext import (
     convert_py_namespace_to_cpp_header_def,
     convert_py_to_cpp_namespace,
     convert_py_namespace_to_includes_dir,
-    convert_py_namespace_to_header_filename)
+    convert_py_namespace_to_header_filename,
+    escape_yaml_doublequoted)
 
 
 def test_cpp_namespace_code():
@@ -55,3 +56,13 @@ def test_includes_dir(python_namespace, expected):
 ])
 def test_header_name(python_namespace, expected):
     assert expected == convert_py_namespace_to_header_filename(python_namespace)  # noqa E501
+
+
+@pytest.mark.parametrize('string,expected', [
+    ('hello world', 'hello world'),
+    ('hello "world"', 'hello \\"world\\"'),
+    ("hello 'world'", "hello 'world'"),
+    ("hello \\ world", "hello \\\\ world"),
+])
+def test_escape_yaml_doublequoted(string, expected):
+    assert expected == escape_yaml_doublequoted(string)


### PR DESCRIPTION
- A new Jinja filter, `escape_yaml_doublequoted`, is available as part of the `templatekit.TemplatekitExtension`. This filter is meant to be used with template variables that are inside double-quoted string fields in a YAML file. The filter escapes both double quote characters (`"`) and backslash characters (`\`).
- There is a new "Template developer" guide, which lists the `escape_yaml_doublequoted` filter and provides tips on how to write YAML files in templates.
- The development procedure is now part of the documentation, rather than the README.
