### PR TITLE
DM-21707: Add templatekit check command

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,15 @@
 Change log
 ##########
 
+Unreleased
+==========
+
+- Added a new ``templatekit check`` command.
+  This command helps both developers and CI scripts ensure that the template repository is well-structured and that all examples are up-to-date.
+  The ``templatekit check`` command runs ``scons`` to regenerate examples, and then checks the Git state to ensure that there are no untracked or modified files, which might indicate that there are uncommitted changes to examples.
+- Internally, the ``templatekit.Repo`` class exposes a ``git.Repo`` instance from GitPython_.
+  See ``templatekit.Repo.gitrepo``, ``templatekit.Repo.is_git_dirty``, and ``templatekit.Repo.untracked_files``.
+
 0.3.0 (2019-10-08)
 ==================
 
@@ -40,3 +49,4 @@ Change log
 (`DM-16940 <https://jira.lsstcorp.org/browse/DM-16940>`__)
 
 .. _Templatebot: https://github.com/lsst-sqre/templatebot
+.. _GitPython: https://gitpython.readthedocs.io/en/stable/index.html

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Change log
 ##########
 
-Unreleased
-==========
+0.4.0 (2019-10-15)
+==================
 
 - Added a new ``templatekit check`` command.
   This command helps both developers and CI scripts ensure that the template repository is well-structured and that all examples are up-to-date.

--- a/docs/development-guide.rst
+++ b/docs/development-guide.rst
@@ -2,6 +2,9 @@
 Development guide
 #################
 
+This page describes how to develop Templatekit, the Python package.
+For information on developing templates *in* a template repository, see the :doc:`template-guide/index`.
+
 Building and testing
 ====================
 
@@ -56,6 +59,10 @@ Starting from a development branch:
       git tag -s X.Y.Z -m "X.Y.Z"
       git push --tags
 
-Travis CI will create a new release on PyPI.
+   Travis CI will create a new release on PyPI.
+5. Update projects that depend on Templatekit:
+
+   - https://github.com/lsst/templates
+   - https://github.com/lsst-sqre/templatebot
 
 .. _virtual environment: https://docs.python.org/3/library/venv.html

--- a/docs/template-guide/index.rst
+++ b/docs/template-guide/index.rst
@@ -7,5 +7,6 @@ This guide will help you develop templates for the templatekit system.
 .. toctree::
    :maxdepth: 1
 
+   workflow
    templatekit-jinja-extensions
    templating-yaml-files

--- a/docs/template-guide/workflow.rst
+++ b/docs/template-guide/workflow.rst
@@ -1,0 +1,80 @@
+#############################
+Template development workflow
+#############################
+
+This page describes the general workflow for developing and maintaining templates in a template repository.
+
+.. note::
+
+   Though this page uses the LSST template repository at https://github.com/lsst/templates as a specific example, these steps apply to any Templatekit-compliant repository.
+   Substitute in your repository's URL and GitHub workflow as necessary.
+
+Step 1: Clone the repository and install templatekit
+====================================================
+
+From a shell, clone the template repository:
+
+.. code-block:: sh
+
+   git clone https://github.com/lsst/templates
+   cd templates
+
+Install the version of Templatekit that's used by the repository:
+
+.. code-block:: sh
+
+   pip install -r requirements.txt
+
+.. tip::
+
+   Install Templatekit and other dependencies in a virtual environment, such as venv_.
+
+Step 2: Make your changes
+=========================
+
+Before making any changes, it's a good idea to **create a new Git branch or work from a GitHub fork.**
+Refer to the guidelines of your template repository or organization for a concrete workflow.
+
+Refer to the :doc:`index` for guides on how to add and modify templates in a Templatekit-compliant repository.
+
+Step 3: Regenerate examples
+===========================
+
+In a shell, run the :command:`scons` command to regenerate the examples:
+
+.. code-block:: sh
+
+   scons
+
+Ensure that :command:`scons` ran properly.
+If it didn't, there is likely an issue with either the templates or the ``SConstruct`` files.
+
+Next, check for any modified files:
+
+.. code-block:: sh
+
+   git status
+
+Review the changes for correctness.
+If the generated examples don't look right, you'll need to adjust the templates and rerun :command:`scons`.
+
+Once the changes are correct, commit the changes with Git.
+
+Step 4: Check the repository
+============================
+
+In a shell, run Templatekit's repository validation command:
+
+.. code-block:: sh
+
+   templatekit check
+
+The ``templatekit check`` command ensures that the structure of the template repository is correct and that the examples are consistent with the templates.
+
+Step 5: Create a Pull Request
+=============================
+
+Your changes are ready to publish.
+Follow the guidelines published by your template repository or organization.
+
+.. _venv: https://docs.python.org/3/library/venv.html

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,8 @@ install_requires = [
     'click>=6.7,<7.0',
     'pyperclip>=1.6.0,<1.7.0',
     'PyYAML>=5.1',
-    'Cerberus>=1.2,<2.0'
+    'Cerberus>=1.2,<2.0',
+    'GitPython>=3.0.0',
 ]
 
 # Test dependencies

--- a/templatekit/repo.py
+++ b/templatekit/repo.py
@@ -12,6 +12,7 @@ import itertools
 import logging
 from pathlib import Path
 import json
+import subprocess
 
 import yaml
 import cerberus
@@ -185,6 +186,20 @@ class Repo(object):
         fs_items.sort()
         fs_items = [os.path.join(dirname, item) for item in fs_items]
         return [fs_item for fs_item in fs_items if os.path.isdir(fs_item)]
+
+    def build(self):
+        """Run a scons build of the template repository.
+
+        This method runs the ``scons`` command, and thus regenerates examples
+        for each template.
+
+        Returns
+        -------
+        result : `subprocess.CompletedProcess`
+            The result of the ``scons`` execution. See
+            `subprocess.CompletedProcess` for details.
+        """
+        return subprocess.run(['scons'], shell=True, cwd=self.root)
 
 
 class BaseTemplate(object):

--- a/templatekit/scripts/check.py
+++ b/templatekit/scripts/check.py
@@ -1,0 +1,100 @@
+"""Subcommand for checking a template repository for valid structure and
+operation.
+"""
+
+__all__ = ('check',)
+
+import sys
+
+import click
+
+
+@click.command(short_help='Check the template repository')
+@click.pass_obj
+def check(state):
+    """Check the template repository for valid structure and operation.
+
+    The following checks are performed:
+
+    1. Test for untracked files in the Git repository.
+    2. Test for modified, but uncommitted, changes in the Git repository.
+
+    Note:
+
+    - A non-zero status code is returned if the checks fail.
+    - This command always recompiles the examples by running the scons
+      command.
+    """
+    repo = state['repo']
+    print('Testing template repository {0!s}'.format(repo.root))
+    scons_result = repo.build()
+    if scons_result.returncode > 0:
+        message = (
+            '"scons" failed with status {0!d}\n\nThis means that the examples '
+            'could not be successfully generated because of an issue with the '
+            'Cookiecutter templates. Check the scons output, above, for '
+            'debugging hints.'
+        )
+        sys.exit(message.format(scons_result.returncode))
+
+    error_count = 0
+    error_count += _test_git_state(repo)
+
+    if error_count == 1:
+        sys.exit('\n❌ The template repository checks failed with '
+                 '{0:d} error'.format(error_count))
+    elif error_count > 1:
+        sys.exit('\n❌ The template repository checks failed with '
+                 '{0:d} errors'.format(error_count))
+    else:
+        print('✅ Passed!')
+
+
+def _test_git_state(repo):
+    """Test if the Git repository of the template repository is clean.
+    (no modified files and no untracked files).
+    """
+    error_count = 0
+
+    if repo.is_git_dirty():
+        error_count += _test_untracked_files(repo)
+        error_count += _test_uncommitted_changes(repo)
+
+    return error_count
+
+
+def _test_untracked_files(repo):
+    untracked_paths = repo.untracked_files
+    error_count = 0
+    if len(untracked_paths) > 0:
+        print('\n🔴 Untracked files:')
+        for p in untracked_paths:
+            print('  {}'.format(p))
+            error_count += 1
+    return error_count
+
+
+def _test_uncommitted_changes(repo):
+    error_count = 0
+    # Get all uncommitted changes because we don't have a count of them
+    # otherwise
+    uncommitted_changes = []
+    diffindex = repo.get_uncommitted_files()
+    for changetype in diffindex.change_type:
+        for change in diffindex.iter_change_type(changetype):
+            # For deleted files, we want to use the original ("a") path.
+            # Otherwise, we tend to want to show the user the new ("b") path
+            if changetype in ('D',):
+                uncommitted_changes.append(
+                    '{0} {1}'.format(changetype, change.a_path)
+                )
+            else:
+                uncommitted_changes.append(
+                    '{0} {1}'.format(changetype, change.b_path)
+                )
+            error_count += 1
+    if error_count > 0:
+        print('\n🔴 Uncommitted changes:')
+        for change in uncommitted_changes:
+            print(change)
+    return error_count

--- a/templatekit/scripts/main.py
+++ b/templatekit/scripts/main.py
@@ -8,6 +8,7 @@ import click
 from ..repo import Repo
 from .listtemplates import list_templates
 from .make import make
+from .check import check
 
 
 # Add -h as a help shortcut option
@@ -55,3 +56,4 @@ def help(ctx, topic, **kw):
 # Add subcommands from other modules
 main.add_command(list_templates, name='list')
 main.add_command(make)
+main.add_command(check)


### PR DESCRIPTION
- Added a new `templatekit check` command. This command helps both developers and CI scripts ensure that the template repository is well-structured and that all examples are up-to-date. The `templatekit check` command runs `scons` to regenerate examples, and then checks the Git state to ensure that there are no untracked or modified files, which might indicate that there are uncommitted changes to examples.
- Internally, the `templatekit.Repo` class exposes a ``git.Repo`` instance from GitPython. See ``templatekit.Repo.gitrepo``, ``templatekit.Repo.is_git_dirty``, and ``templatekit.Repo.untracked_files``.
- Adds docs around the development workflow for template repository's featuring `templatekit check`.