### PR TITLE
DM-23661: Unpin click dependency (0.4.1 release)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Change log
 ##########
 
+0.4.1 (2020-02-26)
+==================
+
+- The click dependency is no longer pinned.
+  This fixes compatibility with cookiecutter 1.7, which requires click 7.
+
 0.4.0 (2019-10-15)
 ==================
 

--- a/setup.py
+++ b/setup.py
@@ -37,8 +37,8 @@ tests_require += install_requires
 
 # Sphinx documentation dependencies
 docs_require = [
-    'documenteer[pipelines]>=0.4.0,<0.5.0',
-    'sphinx-click>=1.2.0,<1.3.0',
+    'documenteer[pipelines]>=0.5.0,<0.6.0',
+    'sphinx-click',
 ]
 
 # Optional dependencies (like for dev)

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ install_requires = [
     'cookiecutter>=1.6.0,<2.0.0',
     'Jinja2>=2.10,<3.0.0',
     'scons>=3.0.1,<3.1.0',
-    'click>=6.7,<7.0',
+    'click',
     'pyperclip>=1.6.0,<1.7.0',
     'PyYAML>=5.1',
     'Cerberus>=1.2,<2.0',


### PR DESCRIPTION
This PR unpins templatekit's click dependency. This fixes compatibility with cookiecutter >=1.7, which requires click >= 7.