### PR TITLE
[DM-33981] Fix PyPI uploads

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -118,6 +118,6 @@ jobs:
 
       - name: Upload
         uses: pypa/gh-action-pypi-publish@v1.5.0
-        env:
+        with:
           user: "__token__"
           password: ${{ secrets.PYPI_SQRE_ADMIN }}


### PR DESCRIPTION
with, not env, to pass the credentials to the action.