### PR TITLE
[DM-33981] Fix imports of Scons symbols, error reporting

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Change log
 ##########
 
+0.5.1 (2022-03-15)
+==================
+
+- Fix an incorrect import in the SCons builder.
+- Fix reporting of SCons status in ``templatekit check``.
+
 0.5.0 (2022-03-15)
 ==================
 

--- a/src/templatekit/builder.py
+++ b/src/templatekit/builder.py
@@ -27,7 +27,8 @@ from typing import List, Tuple
 
 from cookiecutter.find import find_template
 from cookiecutter.main import cookiecutter
-from SCons.Script import Builder, Environment, Node
+from SCons.Node import Node
+from SCons.Script import Builder, Environment
 
 from .filerender import render_and_write_file_template
 from .textutils import reformat_content_lines
@@ -40,11 +41,11 @@ def build_file_template(
 
     Parameters
     ----------
-    target : `list` of `Scons.Script.Node`
+    target : `list` of `SCons.Node.Node`
         A list of Node objects corresponding to examples to be built.
-    source : `list` of `Scons.Script.Node`
+    source : `list` of `SCons.Node.Node`
         A list of Node objects corresponding to file templates.
-    env : `Scons.Script.Environment`
+    env : `SCons.Script.Environment`
         The construction environment used for building the target.
     """
     target_path = str(target[0])
@@ -75,12 +76,12 @@ def build_project_template(
 
     Parameters
     ----------
-    target : `list` of `Scons.Script.Node`
+    target : `list` of `SCons.Node.Node`
         A list of Node objects corresponding to examples to be built.
-    source : `list` of `Scons.Script.Node`
+    source : `list` of `SCons.Node.Node`
         A list of Node objects containing only the ``cookiecutter.json`` file
         node.
-    env : `Scons.Script.Environment`
+    env : `SCons.Script.Environment`
         The construction environment used for building the target. The
         following construction environment variables are used:
 
@@ -149,11 +150,11 @@ def format_content(
 
     Parameters
     ----------
-    target : `list` of `Scons.Script.Node`
+    target : `list` of `SCons.Node.Node`
         A list of Node objects corresponding to examples to be built.
-    source : `list` of `Scons.Script.Node`
+    source : `list` of `SCons.Node.Node`
         A list of Node objects corresponding to file templates.
-    env : `Scons.Script.Environment`
+    env : `SCons.Script.Environment`
         The construction environment used for building the target.
     """
     target_path = str(target[0])

--- a/src/templatekit/scripts/check.py
+++ b/src/templatekit/scripts/check.py
@@ -33,7 +33,7 @@ def check(state: Dict[str, Repo]) -> None:
     scons_result = repo.build()
     if scons_result.returncode > 0:
         message = (
-            '"scons" failed with status {0!d}\n\nThis means that the examples '
+            '"scons" failed with status {0:d}\n\nThis means that the examples '
             "could not be successfully generated because of an issue with the "
             "Cookiecutter templates. Check the scons output, above, for "
             "debugging hints."

--- a/tests/test_base_template.py
+++ b/tests/test_base_template.py
@@ -36,7 +36,7 @@ def test_validation(templates_repo: str) -> None:
     "path,expected",
     [
         ("file_templates/license_gplv3", "license_gplv3"),
-        ("project_templates/example_project", "example_project"),
+        ("project_templates/fastapi_safir_app", "fastapi_safir_app"),
     ],
 )
 def test_name(templates_repo: str, path: str, expected: str) -> None:
@@ -50,7 +50,7 @@ def test_name(templates_repo: str, path: str, expected: str) -> None:
     "path",
     [
         "file_templates/license_gplv3",
-        "project_templates/example_project",
+        "project_templates/fastapi_safir_app",
     ],
 )
 def test_cookiecutter_json_path(templates_repo: str, path: str) -> None:

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -89,9 +89,9 @@ def test_getitem(templates_repo: str) -> None:
         assert isinstance(copyright_template, FileTemplate)
         assert copyright_template.name == "copyright"
 
-        example_project_template = repo["example_project"]
+        example_project_template = repo["fastapi_safir_app"]
         assert isinstance(example_project_template, ProjectTemplate)
-        assert example_project_template.name == "example_project"
+        assert example_project_template.name == "fastapi_safir_app"
 
 
 def test_contains(templates_repo: str) -> None:
@@ -100,5 +100,5 @@ def test_contains(templates_repo: str) -> None:
         repo = Repo(".")
 
         assert "copyright" in repo
-        assert "example_project" in repo
+        assert "fastapi_safir_app" in repo
         assert "whatwhat" not in repo


### PR DESCRIPTION
When testing with templates, a couple of errors were found:

- `Node` must be imported from `SCons.Node`, not `SCons.Script`
- Error reporting on check used `{0!d}`, which is not a valid format specifier

Also update the submodule that's used for testing, and use a current template.