### PR TITLE
[DM-33981] Separate out the periodic CI run

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,8 +14,6 @@ name: Python CI
     tags:
       - "*"
   pull_request: {}
-  schedule:
-    - cron: "0 12 * * 1"
 
 jobs:
   test:
@@ -38,6 +36,8 @@ jobs:
         uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python }}
+          cache: "pip"
+          cache-dependency-path: "setup.cfg"
 
       - name: Run pre-commit
         uses: pre-commit/action@v2.0.3
@@ -54,14 +54,6 @@ jobs:
           # impact the tox environment.
           key: tox-${{ matrix.python }}-${{ hashFiles('pyproject.toml', 'setup.cfg') }}
 
-      # If and only if this is the scheduled weekly CI run, move the pin of
-      # the templates repository used for test data before running the tests.
-      # This ensures that templatekit still works with the current templates
-      # repository.
-      - name: Update template test data
-        run: git submodule update --remote
-        if: github.event_name == 'schedule'
-
       - name: Run tox
         run: tox -e py,typing
 
@@ -76,6 +68,8 @@ jobs:
         uses: actions/setup-python@v3
         with:
           python-version: "3.10"
+          cache: "pip"
+          cache-dependency-path: "setup.cfg"
 
       - name: Install Graphviz
         run: sudo apt-get install graphviz
@@ -96,9 +90,8 @@ jobs:
           LTD_PASSWORD: ${{ secrets.LTD_PASSWORD }}
         run: ltd upload --product templatekit --gh --dir docs/_build/html
         if: >
-          github.event_name != 'schedule'
-          && (github.event_name != 'pull_request'
-              || startsWith(github.head_ref, 'tickets/'))
+          github.event_name != 'pull_request'
+          || startsWith(github.head_ref, 'tickets/')
 
   pypi:
 
@@ -115,6 +108,8 @@ jobs:
         uses: actions/setup-python@v3
         with:
           python-version: "3.10"
+          cache: "pip"
+          cache-dependency-path: "setup.cfg"
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/periodic.yaml
+++ b/.github/workflows/periodic.yaml
@@ -1,0 +1,48 @@
+# This is a separate run of the Python test suite that doesn't cache the tox
+# environment and runs from a schedule.  The purpose is to test compatibility
+# with the latest versions of all modules Templatekit depends on, since
+# Templatekit (being a library) does not pin its dependencies.
+
+name: Periodic CI
+
+"on":
+  schedule:
+    - cron: "0 12 * * 1"
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        python:
+          - "3.8"
+          - "3.9"
+          - "3.10"
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+
+      - name: Set up Python
+        uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.python }}
+          cache: "pip"
+          cache-dependency-path: "setup.cfg"
+
+      - name: Run pre-commit
+        uses: pre-commit/action@v2.0.3
+
+      - name: Install tox
+        run: pip install tox tox-docker
+
+      # Move the pin of the templates repository used for test data before
+      # running the tests.  This ensures that templatekit still works with the
+      # current templates repository.
+      - name: Update template test data
+        run: git submodule update --remote
+
+      - name: Run tox
+        run: tox -e py,typing


### PR DESCRIPTION
When applying the same pattern to Safir, I realized that a weekly
periodic run might refresh the tox environment cache frequently
enough that it would always be considered current and the tox
environments would never be recreated, thus defeating the point of
testing against the latest version.

Follow the Safir setup and instead separate the periodic run into
a different workflow that doesn't use the tox environment cache.
Share a pip cache across all the workflows to still minimize
downloads.