### PR TITLE
Fix project name

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -75,7 +75,7 @@ jobs:
           github.event_name != 'pull_request'
           || startsWith(github.head_ref, 'tickets/')
         with:
-          project: "example"
+          project: "templatekit"
           dir: "docs/_build/html"
           username: ${{ secrets.LTD_USERNAME }}
           password: ${{ secrets.LTD_PASSWORD }}


### PR DESCRIPTION
The name was "example", but of course should be templatekit. This was preventing uploads to LTD.